### PR TITLE
🎨 Design : 디폴트 레이아웃 콘텐츠 영역 수정

### DIFF
--- a/src/components/layouts/AppHeader.vue
+++ b/src/components/layouts/AppHeader.vue
@@ -30,10 +30,10 @@ const onProfileClick = () => {
 @use '@/assets/styles/utils/_pxToRem.scss' as *;
 
 .header-wrap {
-  position: fixed;
-  top: 0;
-  left: 0;
-  z-index: 100;
+  // position: fixed;
+  // top: 0;
+  // left: 0;
+  // z-index: 100;
   width: 100%;
   display: flex;
   justify-content: center;

--- a/src/components/layouts/AppNavbar.vue
+++ b/src/components/layouts/AppNavbar.vue
@@ -76,10 +76,10 @@ const isActive = computed(() => (menu) => {
 @use '@/assets/styles/utils/_pxToRem.scss' as *;
 
 .nav-wrap {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  z-index: 100;
+  // position: fixed;
+  // bottom: 0;
+  // left: 0;
+  // z-index: 100;
   width: 100%;
   display: flex;
   justify-content: center;

--- a/src/components/layouts/DefaultLayout.vue
+++ b/src/components/layouts/DefaultLayout.vue
@@ -37,29 +37,37 @@ const showNav = computed(() => visableNav.includes(route.name))
 @use '@/assets/styles/utils/_pxToRem.scss' as *;
 
 .layout-wrapper {
+  /* ✅ 뷰포트에 고정된 ‘앱 프레임’ */
+  position: fixed;
+  inset: 0; /* top:0; right:0; bottom:0; left:0 */
   margin: 0 auto;
-  /* ★ 아이폰 15 Pro Max 너비 적용 */
   max-width: rem(430px);
   width: 100%;
-  min-height: 100vh;
+
+  display: flex;
+  flex-direction: column;
 
   /* main.css의 기본 배경색 적용 */
   background-color: var(--bg-default);
-
-  /* 고정 헤더(56px)와 네비바(70px)에
-    내용이 가려지지 않도록 패딩 추가
-  */
-  padding-top: rem(56px);
-  padding-bottom: rem(70px);
 }
 
+/* 가운데 영역만 스크롤 */
 .slot-container {
-  /* 페이지 내용이 흰색 배경을 갖도록 */
-  background-color: var(--bg-partition); /* */
+  flex: 1;
   width: 100%;
-  /* 레이아웃 래퍼의 min-height(100vh)에서
-    패딩값을 뺀 실제 화면 높이를 채우도록 설정
-  */
-  min-height: calc(100vh - rem(56px) - rem(70px));
+  box-sizing: border-box;
+
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+
+  background-color: var(--bg-partition);
+  &::-webkit-scrollbar {
+    display: none;
+  }
+  /* 파이어폭스 */
+  scrollbar-width: none;
+
+  /* IE, 옛 엣지 */
+  -ms-overflow-style: none;
 }
 </style>


### PR DESCRIPTION
# 🔥 Pull requests

### 🌴 작업한 브랜치

- #11  

### ✅ 작업한 내용

- Header, Navbar Fixed 상태 해제
- 디폴트 레이아웃에서 .layout-wrapper 를 뷰포트에 Fixed
- 가운데 main.slot-container 만 overflow-y: auto 로 스크롤

### ❗️PR Point

- 현재 스크롤 바는 none 상태로 보이지 않게 설정했습니다. 
- 스크롤바 커스텀이 가능할 듯 하여, 커스텀을 하게 된다면 다른 issue에서 따로 디자인 들어가면 좋을 듯 합니다.
- 관련 추가 자료로 링크 남깁니다. 
  - https://inpa.tistory.com/entry/CSS-%F0%9F%8C%9F-%EC%8A%A4%ED%81%AC%EB%A1%A4-%EB%B0%94Scrollbar-%EA%BE%B8%EB%AF%B8%EA%B8%B0-%EC%86%8D%EC%84%B1-%EC%B4%9D%EC%A0%95%EB%A6%AC

### 📸 스크린샷

<img width="600" height="966" alt="스크린샷 2025-12-02 215122" src="https://github.com/user-attachments/assets/e3df2098-c210-41a7-99cf-f72266525353" />

closed #11 